### PR TITLE
📃 #25 fix the code concepts link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Or use a CDN:
 
 # Getting Started
 
-After making sure that Astral.js is available in modules, we can start looking into how we can actually use it. But before we dive into the code, it’s a good measure to take a look at the [Core Concepts](#core_concepts) section of the documentation if you haven’t done already or are not up to date with the recent updates in the features. Once you are confident about your knowledge of the core concepts, we can dive into the practical usage of Astral.js.
+After making sure that Astral.js is available in modules, we can start looking into how we can actually use it. But before we dive into the code, it’s a good measure to take a look at the [Core Concepts](#core-concepts) section of the documentation if you haven’t done already or are not up to date with the recent updates in the features. Once you are confident about your knowledge of the core concepts, we can dive into the practical usage of Astral.js.
 
 Here we are going to divide the usage into 3 different sections, covering the use of the Event, Context, and Layout functionalities respectively.
 


### PR DESCRIPTION
Fixed broken hyperlink in the Getting Started section

This pull request addresses the issue of a broken hyperlink in the "Getting Started" section of the readme.md file. The existing hyperlink reference to the "Core Concepts" section was incorrect and did not navigate to the intended location. I have fixed the hyperlink by replacing it with the correct anchor link that matches the heading in the "Core Concepts" section.

Changes made:

Replaced the broken hyperlink reference with the correct anchor link to the "Core Concepts" section.
Ensured that the anchor link matches the heading in the "Core Concepts" section.
Please review this pull request and consider merging it into the main branch. Thank you for your attention and consideration.

Related issue: [#25 ]